### PR TITLE
`robots.txt`においてサイトマップを示しているアドレスを直した

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,4 +2,4 @@
 User-agent: Googlebot-Image
 Disallow: /
 
-sitemap: https://zdk.tsukuba.ac.jp/sitemap-index.xml
+sitemap: https://hello.zdk.tsukuba.ac.jp/sitemap-index.xml


### PR DESCRIPTION
fix #37 