### PR TITLE
faqに目次を追加

### DIFF
--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -63,14 +63,6 @@ const ids = hashes.map((h) => h.slice(0, hashLength));
 </Layout>
 
 <style>
-  .question {
-    font-size: 1.3rem;
-    font-weight: bold;
-  }
-  .question::before {
-    content: "Q. ";
-  }
-
   .toc-nav {
     padding: 16px;
     border: solid 1px var(--border-color);
@@ -83,13 +75,12 @@ const ids = hashes.map((h) => h.slice(0, hashLength));
   }
   .toc {
     ol {
-      padding-inline-start: 0;
+      padding-inline-start: 24px;
     }
     ol ol {
       padding-inline-start: 16px;
     }
     li {
-      list-style-type: none;
       color: var(--link-color);
       font-weight: 700;
     }
@@ -109,6 +100,7 @@ const ids = hashes.map((h) => h.slice(0, hashLength));
     padding: 16px;
     width: 620px;
     margin: 8px auto;
+    counter-reset: number 0;
   }
   .faq-item {
     padding: 0.5em 1em;
@@ -116,6 +108,14 @@ const ids = hashes.map((h) => h.slice(0, hashLength));
     background: #fff;
     border: solid 3px #60d398; /*線*/
     border-radius: 10px; /*角の丸み*/
+  }
+  .question {
+    font-size: 1.3rem;
+    font-weight: bold;
+  }
+  .question::before {
+    counter-increment: number 1;
+    content: "Q" counter(number) ".";
   }
   @media screen and (max-width: 768px) {
     .faq-item {

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -15,27 +15,80 @@ console.dir(faqs);
 <Layout pageTitle="よくある質問">
   <div class="container">
     <h1>よくある質問</h1>
-    <dl>
+    <nav class="toc-nav">
+      <h2 class="toc-title">目次</h2>
+      <div class="toc"></div>
+    </nav>
+    <article>
       {
         faqs.map((faq) => (
           <div class="faq-item">
-            <dt>{faq.question}</dt>
-            <dd set:html={faq.answerHtml} />
+            <h2 class="question">{faq.question}</h2>
+            <div set:html={faq.answerHtml} />
           </div>
         ))
       }
-    </dl>
+    </article>
   </div>
+
+  <script>
+    import * as tocbot from "tocbot";
+
+    tocbot.init({
+      tocSelector: ".toc", // 目次を追加するクラス名
+      contentSelector: "article", // 目次を取得するコンテンツ
+      activeLinkClass: "to-link-active", // アクティブになった時のクラス名
+      listClass: "toc-list", // olのクラス名
+      linkClass: "toc-link", // aタグのクラス名
+      headingSelector: "h2, h3", // 目次として取得する見出しタグ
+    });
+  </script>
+
   <Footer showTopLink={true} />
 </Layout>
 
 <style>
-  dt {
+  .question {
     font-size: 1.3rem;
     font-weight: bold;
   }
-  dt::before {
+  .question::before {
     content: "Q. ";
+  }
+
+  .toc-nav {
+    padding: 16px;
+    border: solid 1px var(--border-color);
+    border-radius: 8px;
+    width: fit-content;
+  }
+  .toc-title {
+    margin: 0;
+    font-size: 1.2rem;
+  }
+  .toc {
+    ol {
+      padding-inline-start: 0;
+    }
+    ol ol {
+      padding-inline-start: 16px;
+    }
+    li {
+      list-style-type: none;
+      color: var(--link-color);
+      font-weight: 700;
+    }
+    ol ol > li {
+      font-weight: normal;
+    }
+    a {
+      font-size: 1rem;
+      color: var(--link-color);
+      text-decoration: none;
+    }
+    a:hover {
+      color: var(--text-color);
+    }
   }
   .container {
     padding: 16px;

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -1,4 +1,5 @@
 ---
+import * as crypto from "crypto";
 import remarkParse from "remark-parse";
 import { unified } from "unified";
 import { fetchPost } from "../esa-utils/fetch";
@@ -10,6 +11,18 @@ const faqPost = await fetchPost(import.meta.env.ESA_FAQ_NUMBER);
 const faqNodes = unified().use(remarkParse).parse(faqPost.body_md);
 const faqs = parseFaqs(faqNodes);
 console.dir(faqs);
+
+const hashes = faqs.map((faq) =>
+  crypto.createHash("md5").update(faq.question).digest("hex"),
+);
+let hashLength = 7;
+while (
+  new Set(hashes.map((h) => h.slice(0, hashLength))).size !== hashes.length
+) {
+  hashLength++;
+}
+console.log("assured unique id w/hashLength: ", hashLength);
+const ids = hashes.map((h) => h.slice(0, hashLength));
 ---
 
 <Layout pageTitle="よくある質問">
@@ -21,9 +34,11 @@ console.dir(faqs);
     </nav>
     <article>
       {
-        faqs.map((faq) => (
+        faqs.map((faq, i) => (
           <div class="faq-item">
-            <h2 class="question">{faq.question}</h2>
+            <h2 class="question" id={ids[i]}>
+              {faq.question}
+            </h2>
             <div set:html={faq.answerHtml} />
           </div>
         ))


### PR DESCRIPTION
FAQページに目次を追加

close #68 

- id は質問文のハッシュ値の先頭7文字として設定
- before 擬似要素として Q1, Q12 のような質問番号を付与
- 目次にも番号を付与（個別記事ページには番号はない）