### PR TITLE
コンポーネントに分離 StyledHtml, Toc

### DIFF
--- a/src/components/StyledHtml.astro
+++ b/src/components/StyledHtml.astro
@@ -1,0 +1,60 @@
+---
+export interface Props {
+  html: string;
+}
+const { html } = Astro.props;
+---
+
+<div class="html-container" set:html={html} />
+
+<style is:inline>
+  .html-container {
+    img {
+      max-width: 100%;
+      max-height: 30rem;
+      display: block;
+      margin: 8px 0;
+    }
+    h1 {
+      font-size: 2rem;
+    }
+    h2 {
+      border-inline-start: 7px solid var(--theme-color);
+      padding-inline-start: 11px;
+      padding-block: 0.1rem;
+      border-block-end: 1px solid var(--border-color);
+    }
+    h3 {
+      border-block-end: 1px solid var(--border-color);
+    }
+    table,
+    th,
+    td {
+      margin: 0;
+      border-spacing: 0;
+    }
+    th,
+    td {
+      border-inline-start: 1px solid var(--border-color);
+      border-block-start: 1px solid var(--border-color);
+    }
+    th:last-of-type,
+    td:last-of-type {
+      border-inline-end: 1px solid var(--border-color);
+    }
+    tr:last-of-type {
+      td {
+        border-block-end: 1px solid var(--border-color);
+      }
+    }
+    a {
+      color: var(--theme-color);
+      text-decoration: none;
+    }
+    a:hover,
+    a:active {
+      color: var(--theme-color-dark);
+      text-decoration: underline;
+    }
+  }
+</style>

--- a/src/components/Toc.astro
+++ b/src/components/Toc.astro
@@ -1,0 +1,54 @@
+<nav class="toc-nav">
+  <h2 class="toc-title">目次</h2>
+  <div class="toc"></div>
+</nav>
+
+<script>
+  import * as tocbot from "tocbot";
+
+  tocbot.init({
+    tocSelector: ".toc", // 目次を追加するクラス名
+    contentSelector: "article", // 目次を取得するコンテンツ
+    activeLinkClass: "to-link-active", // アクティブになった時のクラス名
+    listClass: "toc-list", // olのクラス名
+    linkClass: "toc-link", // aタグのクラス名
+    headingSelector: "h2, h3", // 目次として取得する見出しタグ
+  });
+</script>
+
+<style>
+  .toc-nav {
+    padding: 16px;
+    border: solid 1px var(--border-color);
+    border-radius: 8px;
+    width: fit-content;
+  }
+  .toc-title {
+    border: 0;
+    margin: 0;
+    font-size: 1.2rem;
+  }
+  .toc {
+    ol {
+      padding-inline-start: 24px;
+    }
+    ol ol {
+      padding-inline-start: 16px;
+    }
+    li {
+      color: var(--link-color);
+      font-weight: 700;
+    }
+    ol ol > li {
+      font-weight: normal;
+    }
+    a {
+      font-size: 1rem;
+      color: var(--link-color);
+      text-decoration: none;
+    }
+    a:hover {
+      color: var(--text-color);
+    }
+  }
+</style>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -7,6 +7,7 @@ import Layout from "../layouts/Layout.astro";
 import Footer from "../components/footer.astro";
 import Header from "../components/Header.astro";
 import { getUniqueHashes } from "../esa-utils/hash";
+import StyledHtml from "../components/StyledHtml.astro";
 
 const faqPost = await fetchPost(import.meta.env.ESA_FAQ_NUMBER);
 const faqNodes = unified().use(remarkParse).parse(faqPost.body_md);
@@ -32,7 +33,7 @@ const ids = getUniqueHashes(faqs.map((faq) => faq.question));
               <h2 class="question" id={ids[i]}>
                 {faq.question}
               </h2>
-              <div set:html={faq.answerHtml} />
+              <StyledHtml html={faq.answerHtml} />
             </div>
           ))
         }
@@ -121,9 +122,6 @@ const ids = getUniqueHashes(faqs.map((faq) => faq.question));
   @media screen and (max-width: 768px) {
     .faq-item {
       width: 100%;
-    }
-    dd {
-      margin-left: 8px;
     }
     .container {
       width: 100%;

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -6,6 +6,7 @@ import { parseFaqs } from "../esa-utils/faq-parser";
 import Layout from "../layouts/Layout.astro";
 import Footer from "../components/footer.astro";
 import Header from "../components/Header.astro";
+import Toc from "../components/Toc.astro";
 import { getUniqueHashes } from "../esa-utils/hash";
 import StyledHtml from "../components/StyledHtml.astro";
 
@@ -22,10 +23,7 @@ const ids = getUniqueHashes(faqs.map((faq) => faq.question));
     <Header />
     <div class="article-container">
       <h1 class="title">よくある質問</h1>
-      <nav class="toc-nav">
-        <h2 class="toc-title">目次</h2>
-        <div class="toc"></div>
-      </nav>
+      <Toc />
       <article>
         {
           faqs.map((faq, i) => (
@@ -41,19 +39,6 @@ const ids = getUniqueHashes(faqs.map((faq) => faq.question));
     </div>
     <Footer />
   </div>
-
-  <script>
-    import * as tocbot from "tocbot";
-
-    tocbot.init({
-      tocSelector: ".toc", // 目次を追加するクラス名
-      contentSelector: "article", // 目次を取得するコンテンツ
-      activeLinkClass: "to-link-active", // アクティブになった時のクラス名
-      listClass: "toc-list", // olのクラス名
-      linkClass: "toc-link", // aタグのクラス名
-      headingSelector: "h2, h3", // 目次として取得する見出しタグ
-    });
-  </script>
 </Layout>
 
 <style>
@@ -62,39 +47,6 @@ const ids = getUniqueHashes(faqs.map((faq) => faq.question));
     padding-inline: 16px;
     border-inline-start: 11px solid var(--theme-color-dark);
     border-block-end: 1px solid var(--border-color);
-  }
-  .toc-nav {
-    padding: 16px;
-    border: solid 1px var(--border-color);
-    border-radius: 8px;
-    width: fit-content;
-  }
-  .toc-title {
-    margin: 0;
-    font-size: 1.2rem;
-  }
-  .toc {
-    ol {
-      padding-inline-start: 24px;
-    }
-    ol ol {
-      padding-inline-start: 16px;
-    }
-    li {
-      color: var(--link-color);
-      font-weight: 700;
-    }
-    ol ol > li {
-      font-weight: normal;
-    }
-    a {
-      font-size: 1rem;
-      color: var(--link-color);
-      text-decoration: none;
-    }
-    a:hover {
-      color: var(--text-color);
-    }
   }
   .container {
     width: 620px;

--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -10,6 +10,7 @@ import Layout from "../../layouts/Layout.astro";
 import Footer from "../../components/footer.astro";
 import { imageReplacer } from "../../esa-utils/image-replacer";
 import Header from "../../components/Header.astro";
+import StyledHtml from "../../components/StyledHtml.astro";
 
 /**
  * 動的にページを生成するときに必須の関数
@@ -49,7 +50,9 @@ const articleHtml = await unified()
         <div class="toc"></div>
       </nav>
 
-      <article set:html={articleHtml.toString()} />
+      <article>
+        <StyledHtml html={articleHtml.toString()} />
+      </article>
     </div>
     <Footer />
   </div>
@@ -128,47 +131,6 @@ const articleHtml = await unified()
     }
     .container {
       width: 100%;
-    }
-  }
-</style>
-
-<style is:inline>
-  img {
-    max-width: 100%;
-    max-height: 30rem;
-    display: block;
-    margin: 8px 0;
-  }
-  h1 {
-    font-size: 2rem;
-  }
-  h2 {
-    border-inline-start: 7px solid var(--theme-color);
-    padding-inline-start: 11px;
-    padding-block: 0.1rem;
-    border-block-end: 1px solid var(--border-color);
-  }
-  h3 {
-    border-block-end: 1px solid var(--border-color);
-  }
-  table,
-  th,
-  td {
-    margin: 0;
-    border-spacing: 0;
-  }
-  th,
-  td {
-    border-inline-start: 1px solid var(--border-color);
-    border-block-start: 1px solid var(--border-color);
-  }
-  th:last-of-type,
-  td:last-of-type {
-    border-inline-end: 1px solid var(--border-color);
-  }
-  tr:last-of-type {
-    td {
-      border-block-end: 1px solid var(--border-color);
     }
   }
 </style>

--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -11,6 +11,7 @@ import Footer from "../../components/footer.astro";
 import { imageReplacer } from "../../esa-utils/image-replacer";
 import Header from "../../components/Header.astro";
 import StyledHtml from "../../components/StyledHtml.astro";
+import Toc from "../../components/Toc.astro";
 
 /**
  * 動的にページを生成するときに必須の関数
@@ -45,10 +46,7 @@ const articleHtml = await unified()
     <Header />
     <div class="article-container">
       <h1 class="title">{post.name}</h1>
-      <nav class="toc-nav">
-        <h2 class="toc-title">目次</h2>
-        <div class="toc"></div>
-      </nav>
+      <Toc />
 
       <article>
         <StyledHtml html={articleHtml.toString()} />
@@ -56,19 +54,6 @@ const articleHtml = await unified()
     </div>
     <Footer />
   </div>
-
-  <script>
-    import * as tocbot from "tocbot";
-
-    tocbot.init({
-      tocSelector: ".toc", // 目次を追加するクラス名
-      contentSelector: "article", // 目次を取得するコンテンツ
-      activeLinkClass: "to-link-active", // アクティブになった時のクラス名
-      listClass: "toc-list", // olのクラス名
-      linkClass: "toc-link", // aタグのクラス名
-      headingSelector: "h2, h3", // 目次として取得する見出しタグ
-    });
-  </script>
 </Layout>
 
 <style>
@@ -78,41 +63,6 @@ const articleHtml = await unified()
     padding-block: 0.1rem;
     border-inline-start: 11px solid var(--theme-color-dark);
     border-block-end: 1px solid var(--border-color);
-  }
-  .toc-nav {
-    padding: 16px;
-    border: solid 1px var(--border-color);
-    border-radius: 8px;
-    width: fit-content;
-  }
-  .toc-title {
-    margin: 0;
-    font-size: 1.2rem;
-    border: 0;
-  }
-  .toc {
-    ol {
-      padding-inline-start: 0;
-    }
-    ol ol {
-      padding-inline-start: 16px;
-    }
-    li {
-      list-style-type: none;
-      color: var(--link-color);
-      font-weight: 700;
-    }
-    ol ol > li {
-      font-weight: normal;
-    }
-    a {
-      font-size: 1rem;
-      color: var(--link-color);
-      text-decoration: none;
-    }
-    a:hover {
-      color: var(--text-color);
-    }
   }
   .container {
     width: 620px;


### PR DESCRIPTION
## 概要

- リモートのHTMLに対するスタイルを StyledHtml として分離
  - リンクを緑にした
- 目次を Toc として分離

## なぜ StyledHtml に分離したか

### 現状
esa の Markdown をパースして生成した HTML に対して style をつけるには、class ではなく tag に対して style を当ててやる必要がある。

現状では `<style is:inline>` と、インラインの style タグを挿入することで対応していたが、CSSの詳細度によっては、関係ない部分に対しても style が当たってしまっていた。

<details>
<summary>パースした HTML に対して inline の <style> が必要な理由</summary>

Astro はコンポーネント内の style を当てるとき、自動的に内部のタグを認識して `data-` attribute を追加し、一緒にバンドルすることにより、scoped css を実現している。

`set:html` した HTML タグは Astro によって認識されないため、上記 `data-` attr が付与されず、スタイルが当たらない。
そのため、インラインで style を追加する必要がある。
</details>

### 本PRでのアプローチ

コンポーネントを分離する際も is:inline を用いる必要があるが、`<div class="html-container">` の内側で全てを記述することにより、実質的に scoped css な状況を作り出せた。

### 結果

本PRでは、esa からパースした HTML を使用している FAQ の回答部分**のみ**にも style を当てている。
これは、コンポーネントに分けて生じた再利用可能性、および、scoped css の実現による恩恵である。