### PR TITLE
imageReplacer の中で画像の width, height を指定して CLS を防ぐ

### DIFF
--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -9,9 +9,9 @@ export interface Props {
 }
 const { post } = Astro.props;
 const firstImg = await getFirstImg(post);
-const imgSrc = firstImg ?? backgroundImage.src;
+const img = firstImg ?? backgroundImage;
 const href = `/posts/${post.number}`;
 const title = post.name;
 ---
 
-<Card href={href} title={title} imgSrc={imgSrc} />
+<Card href={href} title={title} imgSrc={img.src} />

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,4 +1,5 @@
 ---
+import { Image } from "astro:assets";
 import ZDK_logo from "../assets/zdk_logo_full.svg";
 ---
 
@@ -14,7 +15,7 @@ import ZDK_logo from "../assets/zdk_logo_full.svg";
   </div>
   <div class="footer__logo-container">
     <a href="https://www.zdk.tsukuba.ac.jp/" class="footer__logo-link">
-      <img src={ZDK_logo.src} alt="全学学類・専門学群・総合学域群代表者会議" />
+      <Image src={ZDK_logo} alt="全学学類・専門学群・総合学域群代表者会議" />
     </a>
   </div>
 </footer>

--- a/src/components/StyledHtml.astro
+++ b/src/components/StyledHtml.astro
@@ -10,6 +10,8 @@ const { html } = Astro.props;
 <style is:inline>
   .html-container {
     img {
+      width: auto;
+      height: auto;
       max-width: 100%;
       max-height: 30rem;
       display: block;

--- a/src/esa-utils/image-replacer.ts
+++ b/src/esa-utils/image-replacer.ts
@@ -15,7 +15,9 @@ export function imageReplacer() {
     await Promise.all(
       imageNodes.map(async (node) => {
         const filepath = await optimizeImage(node.properties.src);
-        node.properties.src = filepath;
+        node.properties.src = filepath.src;
+        node.properties.width = filepath.attributes.width;
+        node.properties.height = filepath.attributes.height;
       }),
     );
   };

--- a/src/esa-utils/nodes.ts
+++ b/src/esa-utils/nodes.ts
@@ -5,6 +5,8 @@ export interface ImgNode extends Node {
   tagName: "img";
   properties: {
     src: string;
+    width?: number;
+    height?: number;
   };
 }
 

--- a/src/esa-utils/optimize-image.ts
+++ b/src/esa-utils/optimize-image.ts
@@ -1,3 +1,4 @@
+import type { GetImageResult } from "astro";
 import { getImage } from "astro:assets";
 
 /**
@@ -13,7 +14,7 @@ export async function optimizeImage(
   low: boolean = false,
   width?: number,
   height?: number,
-): Promise<string> {
+): Promise<GetImageResult> {
   console.log(url);
 
   const img = await getImage({
@@ -25,5 +26,5 @@ export async function optimizeImage(
     height: height,
   });
 
-  return img.src;
+  return img;
 }

--- a/src/esa-utils/thumbnail.ts
+++ b/src/esa-utils/thumbnail.ts
@@ -4,8 +4,9 @@ import rehypeParse from "rehype-parse";
 import { find } from "unist-util-find";
 import { optimizeImage } from "./optimize-image";
 import { isImg } from "./nodes";
+import type { GetImageResult } from "astro";
 
-export function getFirstImg(post: Post): Promise<string> | undefined {
+export function getFirstImg(post: Post): Promise<GetImageResult> | undefined {
   const hast = unified().use(rehypeParse).parse(post.body_html);
   const imgNode = find(hast, { type: "element", tagName: "img" });
   if (isImg(imgNode)) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ const response = await fetchPosts();
 const posts = response.posts;
 const faqPost = await fetchPost(import.meta.env.ESA_FAQ_NUMBER);
 const faqFirstImg = await getFirstImg(faqPost);
-const faqImgSrc = faqFirstImg ?? backgroundImage.src;
+const faqImg = faqFirstImg ?? backgroundImage;
 const blogPosts = posts.filter((post) => post.number !== faqPost.number);
 ---
 
@@ -20,9 +20,10 @@ const blogPosts = posts.filter((post) => post.number !== faqPost.number);
     <h2 class="heading">記事一覧</h2>
     {blogPosts.map((post) => <ArticleCard post={post} />)}
     <h2 class="heading">これってどうなの？</h2>
-    <Card href="/faq" title="よくある質問" imgSrc={faqImgSrc} />
+    <Card href="/faq" title="よくある質問" imgSrc={faqImg.src} />
   </div>
 </Layout>
+
 <style>
   .heading {
     font-size: 1.5rem;


### PR DESCRIPTION
fix #104 

<img width="955" alt="スクリーンショット 2025-03-30 20 39 44" src="https://github.com/user-attachments/assets/eba107b8-8b3c-4299-a380-e62ca095b194" />
