### PR TITLE
Remove alt for card img

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -9,7 +9,7 @@ const { href, title, imgSrc } = Astro.props;
 
 <a class="card" href={href}>
   <h3 class="card-text">{title}</h3>
-  <img class="thumbnail" src={imgSrc} alt={title} />
+  <img class="thumbnail" src={imgSrc} alt="" />
 </a>
 
 <style>


### PR DESCRIPTION
重複して読み上げられるので、alt は空でよい